### PR TITLE
Support for PHP8.1 or later

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "mobiledetect/mobiledetectlib": "^3.74",
         "jaybizzle/crawler-detect": "^1.2"
     },


### PR DESCRIPTION
Can we get  support for PHP8.1 and after that a tag so we can install this fork instead of jenssegers/agent?